### PR TITLE
updates in light of check script changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           PRIVATE_REPOS_KEY: ${{ secrets.PRIVATE_REPOS_KEY }}
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev_env]
+          pip install .[dev]
       - name: Format
         run: |
           check/format_.py
@@ -43,7 +43,7 @@ jobs:
           PRIVATE_REPOS_KEY: ${{ secrets.PRIVATE_REPOS_KEY }}
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev_env]
+          pip install .[dev]
       - name: Pylint
         run: |
           check/pylint_.py --all
@@ -62,7 +62,7 @@ jobs:
           PRIVATE_REPOS_KEY: ${{ secrets.PRIVATE_REPOS_KEY }}
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev_env]
+          pip install .[dev]
       - name: Flake8
         run: |
           check/flake8_.py
@@ -81,7 +81,7 @@ jobs:
           PRIVATE_REPOS_KEY: ${{ secrets.PRIVATE_REPOS_KEY }}
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev_env]
+          pip install .[dev]
       - name: Type check
         run: |
           check/mypy_.py
@@ -100,7 +100,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev_env]
+          pip install .[dev]
       - name: Coverage check
         run: |
           check/coverage_.py
@@ -119,7 +119,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev_env]
+          pip install .[dev]
       - name: Pytest-mac check
         run: |
           check/pytest_.py
@@ -138,7 +138,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev_env]
+          pip install .[dev]
       - name: Pytest-win check
         run: |
           check/pytest_.py
@@ -159,7 +159,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev_env]
+          pip install .[dev]
       - name: Requirements check
         run: |
           check/requirements.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
           PRIVATE_REPOS_KEY: ${{ secrets.PRIVATE_REPOS_KEY }}
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev_env]
       - name: Format
         run: |
           check/format_.py
@@ -44,11 +43,10 @@ jobs:
           PRIVATE_REPOS_KEY: ${{ secrets.PRIVATE_REPOS_KEY }}
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev_env]
       - name: Pylint
         run: |
-          check/pylint_.py
+          check/pylint_.py --all
 
   flake8:
     name: Flake8 check
@@ -64,8 +62,7 @@ jobs:
           PRIVATE_REPOS_KEY: ${{ secrets.PRIVATE_REPOS_KEY }}
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev_env]
       - name: Flake8
         run: |
           check/flake8_.py
@@ -84,11 +81,29 @@ jobs:
           PRIVATE_REPOS_KEY: ${{ secrets.PRIVATE_REPOS_KEY }}
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev_env]
       - name: Type check
         run: |
           check/mypy_.py
+
+  coverage:
+    name: Pytest and Coverage check
+    env:
+      PRIVATE_REPOS_KEY: ${{ secrets.PRIVATE_REPOS_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev_env]
+      - name: Coverage check
+        run: |
+          check/coverage_.py
 
   pytest-mac:
     name: Pytest macOS
@@ -104,8 +119,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+          pip install .[dev_env]
       - name: Pytest-mac check
         run: |
           check/pytest_.py
@@ -124,32 +138,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if (Test-Path "dev-requirements.txt") {pip install -r dev-requirements.txt}
+          pip install .[dev_env]
       - name: Pytest-win check
         run: |
           check/pytest_.py
         shell: bash
-
-  coverage:
-    name: Coverage check
-    env:
-      PRIVATE_REPOS_KEY: ${{ secrets.PRIVATE_REPOS_KEY }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
-      - name: Coverage check
-        run: |
-          check/coverage_.py
 
   requirements:
     name: Requirements check
@@ -166,9 +159,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
-      - name: Coverage check
+          pip install .[dev_env]
+      - name: Requirements check
         run: |
           check/requirements.py
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,1 @@
-applications-superstaq[dev]==0.1.14
+applications-superstaq[dev]==0.1.15

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,2 @@
-black[jupyter]~=22.3.0
-flake8-import-order~=0.18.1
-flake8~=3.8.4
-mypy~=0.961
-nbmake~=1.3.0
-pylint>=2.13.0
-pytest-cov~=2.11.1
-pytest-socket~=0.4.1
-pytest~=6.1.2
+cirq-superstaq[dev]==0.1.29
+qiskit-superstaq[dev]==0.1.23

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,1 @@
-cirq-superstaq[dev]==0.1.29
-qiskit-superstaq[dev]==0.1.23
+applications-superstaq[dev]==0.1.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cirq-superstaq==0.1.29
-qiskit-superstaq==0.1.23
+cirq-superstaq==0.1.30
+qiskit-superstaq==0.1.24
 scikit-learn~=1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cirq-superstaq==0.1.26
-qiskit-superstaq==0.1.21
+cirq-superstaq==0.1.29
+qiskit-superstaq==0.1.23
 scikit-learn~=1.1.1

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import io
-import os
 
 from setuptools import find_packages, setup
 

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,12 @@ description = "SupermarQ is a scalable, application-centric quantum benchmarking
 # README file as long_description.
 long_description = io.open("README.md", encoding="utf-8").read()
 
-
 # Read in requirements
-requirements = open(os.path.dirname(os.path.realpath(__file__)) + "/requirements.txt").readlines()
+requirements = open("requirements.txt").readlines()
 requirements = [r.strip() for r in requirements]
-dev_requirements = open(
-    os.path.dirname(os.path.realpath(__file__)) + "/dev-requirements.txt"
-).readlines()
+
+# Read in dev requirements, installed with 'pip install supermarq[dev]'
+dev_requirements = open("dev-requirements.txt").readlines()
 dev_requirements = [r.strip() for r in dev_requirements]
 
 supermarq_packages = ["supermarq"] + [
@@ -38,9 +37,7 @@ setup(
     author_email="pranav@super.tech",
     python_requires=(">=3.8.0"),
     install_requires=requirements,
-    extras_require={
-        "dev_env": dev_requirements,
-    },
+    extras_require={"dev": dev_requirements},
     license="Apache 2",
     description=description,
     long_description=long_description,


### PR DESCRIPTION
Two points I'm unsure about in this PR:
- looks like `supermarq` already has a `dev` version, but it's called `dev_env`.  Do we want to rename this to mirror `app-ss[dev] / css[dev] / qss[dev]`?
- should we require `css[dev]` and `qss[dev]` in `dev-requirements.txt`, or `app-ss[dev]`?

UPDATE: we will make it `supermarq[dev]`, and I made `dev-requirements.txt` require `app-ss[dev]`