### PR TITLE
Add gss dev requirements installation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ The SupermarQ package is available via `pip` and can be installed in your curren
 pip install supermarq
 ```
 
+## Install Dev Requirements 
+
+This is required if you intend to run checks locally
+
+```
+pip install .[dev]
+```
+
+
 ## Using SupermarQ
 
 The benchmarks are defined as classes within `supermarq/benchmarks/`. Each application


### PR DESCRIPTION
This is to prevent people from being unable to run checks locally because they don't have dev requirements installed.

Related to [177](https://github.com/SupertechLabs/general-superstaq/issues/177)