### PR TITLE
roerder the operations in the bit/phase codes to reduce circuit depth

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,1 @@
-general-superstaq[dev]~=0.3.4
+general-superstaq[dev]~=0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cirq~=1.0.0
-cirq-superstaq~=0.3.9
-qiskit-superstaq~=0.3.9
+cirq-superstaq~=0.3.10
+qiskit-superstaq~=0.3.10
 scikit-learn~=1.0  # supports python 3.7

--- a/supermarq/benchmarks/bit_code.py
+++ b/supermarq/benchmarks/bit_code.py
@@ -32,11 +32,11 @@ class BitCode(Benchmark):
         Args:
         - qubits: Circuit qubits - assumed data on even indices and measurement on odd indices
         """
-        ancilla_qubits = []
-        for i in range(1, len(qubits), 2):
-            yield cirq.CX(qubits[i - 1], qubits[i])
-            yield cirq.CX(qubits[i + 1], qubits[i])
-            ancilla_qubits.append(qubits[i])
+        for qq in range(1, len(qubits), 2):
+            yield cirq.CX(qubits[qq - 1], qubits[qq])
+        for qq in range(1, len(qubits), 2):
+            yield cirq.CX(qubits[qq + 1], qubits[qq])
+        ancilla_qubits = qubits[1::2]
         yield cirq.measure(*ancilla_qubits, key=f"mcm{round_idx}")
         yield [cirq.ops.reset(qubit) for qubit in ancilla_qubits]
 

--- a/supermarq/benchmarks/bit_code.py
+++ b/supermarq/benchmarks/bit_code.py
@@ -32,11 +32,11 @@ class BitCode(Benchmark):
         Args:
         - qubits: Circuit qubits - assumed data on even indices and measurement on odd indices
         """
+        ancilla_qubits = qubits[1::2]
         for qq in range(1, len(qubits), 2):
             yield cirq.CX(qubits[qq - 1], qubits[qq])
         for qq in range(1, len(qubits), 2):
             yield cirq.CX(qubits[qq + 1], qubits[qq])
-        ancilla_qubits = qubits[1::2]
         yield cirq.measure(*ancilla_qubits, key=f"mcm{round_idx}")
         yield [cirq.ops.reset(qubit) for qubit in ancilla_qubits]
 

--- a/supermarq/benchmarks/phase_code.py
+++ b/supermarq/benchmarks/phase_code.py
@@ -37,12 +37,12 @@ class PhaseCode(Benchmark):
         - qubits: Circuit qubits - assumed data on even indices and
                   measurement on odd indices
         """
-        ancilla_qubits = []
+        ancilla_qubits = qubits[1::2]
         yield [cirq.H(q) for q in qubits]
-        for i in range(1, len(qubits), 2):
-            yield cirq.CZ(qubits[i - 1], qubits[i])
-            yield cirq.CZ(qubits[i + 1], qubits[i])
-            ancilla_qubits.append(qubits[i])
+        for qq in range(1, len(qubits), 2):
+            yield cirq.CZ(qubits[qq - 1], qubits[qq])
+        for qq in range(1, len(qubits), 2):
+            yield cirq.CZ(qubits[qq + 1], qubits[qq])
         yield [cirq.H(q) for q in qubits]
         yield cirq.measure(*ancilla_qubits, key=f"mcm{round_idx}")
         yield [cirq.ops.reset(qubit) for qubit in ancilla_qubits]


### PR DESCRIPTION
Credit to @knsmith for catching this.

The script
```python
import supermarq

bit_code = supermarq.benchmarks.bit_code.BitCode(
    num_data_qubits=3, num_rounds=1, bit_state=[0, 0, 0]
)
print(bit_code.circuit())
```
formerly printed
```
0: ───@───────────────────────────────M('meas_all')───
      │                               │
1: ───X───X───────────M('mcm0')───R───M───────────────
          │           │               │
2: ───────@───@───────┼───────────────M───────────────
              │       │               │
3: ───────────X───X───M───────────R───M───────────────
                  │                   │
4: ───────────────@───────────────────M───────────────
```
and now prints
```
0: ───@───────────────────────M('meas_all')───
      │                       │
1: ───X───X───M('mcm0')───R───M───────────────
          │   │               │
2: ───@───@───┼───────────────M───────────────
      │       │               │
3: ───X───X───M───────────R───M───────────────
          │                   │
4: ───────@───────────────────M───────────────
```
This PR makes the same change to the phase code.