### PR TITLE
Update dependencies to match SuperstaQ

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cirq~=1.0.0
-cirq-superstaq~=0.3.16
+cirq~=1.2.0.dev2022
+cirq-superstaq~=0.3.17
 qiskit-superstaq~=0.3.16
 scikit-learn~=1.0  # supports python 3.7


### PR DESCRIPTION
Quick fix to keep SupermarQ dependencies up-to-date with SuperstaQ. 

@vtomole I saw another PR #62 and some others in SuperstaQ that you have an automated way to update dependencies. Could we use that here to keep SupermarQ up to date with the latest css and qss deployments? 

The css and qss packages are mainly used for circuit submissions so automatically updating them shouldn't introduce breaking changes, plus we should probably keep SupermarQ up-to-date with them regardless.